### PR TITLE
(feat): added a support for running a scan using a repeater

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ docker run -it incremental <api_key> <project_id> [cluster - default: app.bright
 ## Contributors
 
 - [Bar Hofesh](https://github.com/bararchy) - creator and maintainer
+- [Dor Shaer](https://github.com/dorshaer) - maintainer

--- a/src/incremental.cr
+++ b/src/incremental.cr
@@ -165,7 +165,7 @@ module Incremental
     def loop
       populate
       loop do
-        puts "Project Summary"
+        puts "\nProject Summary"
         puts "---------------"
         puts "New: #{@new_urls.size}".colorize(:green)
         puts "Vulnerable: #{@vulnerable_urls.size}".colorize(:red)
@@ -234,7 +234,6 @@ module Incremental
           repeaters:           @repeater_id ? [@repeater_id.to_s] : nil
         }.to_json
       )
-      puts response
     rescue e : JSON::ParseException
       puts "Error when trying to start a scan: #{e}".colorize(:red)
     end
@@ -412,7 +411,8 @@ when 4
   end
 else
   puts "Incorrect number of arguments."
-  puts "Usage: script <api_key> <project_id> [cluster(default: app.brightsec.com)] [repeater_id]"
+  puts "Usage: incremental <api_key> <project_id> [cluster(default: app.brightsec.com)] [repeater_id]"
+  puts "Example: incremental my-project-api-key my-project-id eu.brightsec.com my-repeater-id"
   exit 1
 end
 

--- a/src/incremental.cr
+++ b/src/incremental.cr
@@ -222,25 +222,23 @@ module Incremental
 
     private def start_scan(ep : Array(EP), tests : Array(String), type : String, locations : Array(String) = ["body", "fragment", "query"])
       return if ep.empty?
-      
-      request_body = {
-        "tests" => tests,
-        "entryPointIds" => ep.map(&.id),
-        "attackParamLocations" => locations,
-        "projectId" => @project_id,
-        "name" => "Incremental Scan - #{Time.utc} - #{type}",
-      } of String => Array(String) | String
-    
-      # If repeater was chosen then we will set it in the request under the "repeaters" key
-      request_body["repeaters"] = [@repeater_id.not_nil!] if @repeater_id
-    
-      scan_response = get("/api/v1/scans", "POST", body: request_body.to_json)
-      puts request_body
-      puts scan_response
+      response = get(
+        "/api/v1/scans",
+        "POST",
+        body: {
+          tests:                tests,
+          entryPointIds:        ep.map(&.id),
+          attackParamLocations: locations,
+          projectId:            @project_id,
+          name:                 "Incremental Scan - #{Time.utc} - #{type}",
+          repeaters:           @repeater_id ? [@repeater_id.to_s] : nil
+        }.to_json
+      )
+      puts response
     rescue e : JSON::ParseException
       puts "Error when trying to start a scan: #{e}".colorize(:red)
     end
-    
+
     private def evaluate(skip : Bool = false)
       @evaluated = true
       @apis.clear


### PR DESCRIPTION
Sometimes when running a scan a Repeater is needed.
I added a feature to include a Repeater ID when is specified and needed.