### PR TITLE
Improve entry point selection for stored XSS detection

### DIFF
--- a/src/incremental.cr
+++ b/src/incremental.cr
@@ -248,11 +248,11 @@ module Incremental
         puts "    ────────────────────".colorize(:dark_gray)
         puts "    Σ  #{"%6d" % total} Total".colorize(:white)
         puts ""
-        puts "  #{"┌─────────────────────────────────────────┐".colorize(:dark_gray)}"
-        puts "  #{"│".colorize(:dark_gray)} #{"s".colorize(:light_cyan)}  Scan          #{"ea".colorize(:light_cyan)} Evaluate All    #{"│".colorize(:dark_gray)}"
-        puts "  #{"│".colorize(:dark_gray)} #{"r".colorize(:light_cyan)}  Refresh        #{"en".colorize(:light_cyan)} Evaluate New    #{"│".colorize(:dark_gray)}"
-        puts "  #{"│".colorize(:dark_gray)} #{"lo".colorize(:light_cyan)} List Other     #{"q".colorize(:light_cyan)}  Quit            #{"│".colorize(:dark_gray)}"
-        puts "  #{"└─────────────────────────────────────────┘".colorize(:dark_gray)}"
+        puts "  #{"┌────────────────────────────────┐".colorize(:dark_gray)}"
+        puts "  #{"│".colorize(:dark_gray)} #{"s".colorize(:light_cyan)}  Scan        #{"ea".colorize(:light_cyan)} Evaluate All #{"│".colorize(:dark_gray)}"
+        puts "  #{"│".colorize(:dark_gray)} #{"r".colorize(:light_cyan)}  Refresh     #{"en".colorize(:light_cyan)} Evaluate New #{"│".colorize(:dark_gray)}"
+        puts "  #{"│".colorize(:dark_gray)} #{"lo".colorize(:light_cyan)} List Other  #{"q".colorize(:light_cyan)}  Quit         #{"│".colorize(:dark_gray)}"
+        puts "  #{"└────────────────────────────────┘".colorize(:dark_gray)}"
         print "  #{"❯".colorize(:light_cyan)} "
         input = gets.to_s.chomp.downcase
         case input

--- a/src/incremental.cr
+++ b/src/incremental.cr
@@ -90,7 +90,6 @@ module Incremental
     "amazon_s3_takeover",
     "retire_js",
     "secret_tokens",
-    "stored_xss",
   ]
 
   POST_TESTS = [
@@ -107,7 +106,6 @@ module Incremental
     "sqli",
     "ssrf",
     "ssti",
-    "stored_xss",
     "osi",
     "proto_pollution",
     "server_side_js_injection",
@@ -120,7 +118,6 @@ module Incremental
     "excessive_data_exposure",
     "html_injection",
     "unvalidated_redirect",
-    "stored_xss",
     "proto_pollution",
     "server_side_js_injection",
     "header_security",
@@ -128,12 +125,21 @@ module Incremental
     "css_injection",
     "directory_listing",
     "secret_tokens",
+    "insecure_output_handling",
   ]
 
   XML_TESTS = [
     "xxe",
     "xss",
     "secret_tokens",
+  ]
+
+  # Tests that need a wide entry-point set in a single scan so the engine can
+  # discover cross-request relationships (e.g. payload submitted in one endpoint
+  # and reflected in another). Run these once on the union of candidate buckets
+  # instead of repeating them inside per-bucket scans.
+  CROSS_EP_TESTS = [
+    "stored_xss",
   ]
 
   OTHER_TESTS = [
@@ -179,7 +185,6 @@ module Incremental
     "sqli",
     "ssrf",
     "ssti",
-    "stored_xss",
     "unvalidated_redirect",
     "version_control_systems",
     "wordpress",
@@ -349,6 +354,12 @@ module Incremental
       unless @other.empty?
         puts "  #{"▶".colorize(:light_cyan)} Other     #{@other.size} endpoints, #{OTHER_TESTS.size} tests"
         start_scan(@other, OTHER_TESTS, "OTHER")
+        scan_count += 1
+      end
+      cross_ep = (@apis + @posts + @html + @xml + @static + @other).uniq(&.id)
+      unless cross_ep.empty?
+        puts "  #{"▶".colorize(:light_cyan)} CrossEP   #{cross_ep.size} endpoints, #{CROSS_EP_TESTS.size} tests"
+        start_scan(cross_ep, CROSS_EP_TESTS, "CROSS_EP", ["body", "query", "path"])
         scan_count += 1
       end
       puts ""


### PR DESCRIPTION
## Summary

Stored XSS detection needs both an injection source endpoint (with params) and a reflection target endpoint (HTML/XML/JSON/text response) in the **same scan job** so the engine can discover cross-request relationships between them.

Previously `stored_xss` was duplicated across `STATIC_TESTS`, `POST_TESTS`, `HTML_TESTS` and `OTHER_TESTS`. Each bucket scan only saw its own entry points, so the test ran in isolation per bucket and could not correlate injection sources (typically POSTs / APIs) to reflection targets (HTML pages) across buckets. As a result stored XSS was effectively undetectable.

## Change

- New `CROSS_EP_TESTS` group, currently `["stored_xss"]`, runs once on the union of all candidate buckets (`APIs + POSTs + HTML + XML + Static + Other`, deduped by id). This gives the engine the full entry point set it needs to find stored XSS reflections.
- `stored_xss` removed from the per-bucket test arrays where it could never produce a finding on its own.
- Added `insecure_output_handling` to `HTML_TESTS` (it was previously missing despite matching the HTML bucket's relevance criteria).

## Notes

- Adds at most one extra scan job per evaluation. The existing 2k chunking still applies.
- Locations for the cross-EP scan are `body`, `query`, `path` - typical injection surfaces for stored XSS sources.